### PR TITLE
Fix problem when traversing an Optional object

### DIFF
--- a/src/main/java/introspector/model/NodeFactory.java
+++ b/src/main/java/introspector/model/NodeFactory.java
@@ -42,6 +42,15 @@ public class NodeFactory {
 	}
 
 	/**
+	 * Method to know if a the {@code type} parameter is an Optional type.
+	 * @param type The type to know whether it is an Optional
+	 * @return Whether the type is an Optional
+	 */
+	static <T> boolean isOptionalType(Class<T> type) {
+		return type.getName().equals("java.util.Optional");
+	}
+
+	/**
 	 * Factory to create the nodes
 	 * @param name Name of the node
 	 * @param value Runtime object that will be represented as a node
@@ -73,6 +82,8 @@ public class NodeFactory {
 			return new MapNode(name, value, type);
 		if (type.getName().charAt(0) == '[')
 			return new ArrayNode(name, value, type);
+		if (isOptionalType(type))
+			return new OptionalNode(name, value, type);
 		return new ObjectNode(name, value, type);
 	}
 

--- a/src/main/java/introspector/model/OptionalNode.java
+++ b/src/main/java/introspector/model/OptionalNode.java
@@ -1,0 +1,28 @@
+package introspector.model;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Optional;
+
+public class OptionalNode extends AbstractNode implements Node {
+
+    public OptionalNode(String name, Object value, Class<?> type) {
+        super(name,value,type);
+    }
+
+    @Override
+	protected List<Node> getChildren() {
+        List<Node> childs = new ArrayList<>();
+        Optional<?> opt = (Optional<?>) getValue();
+        childs.add(NodeFactory.createNode("IsPresent", opt.isPresent()));
+        opt.map(inner -> NodeFactory.createNode("Value", inner))
+           .ifPresent(inner -> childs.add(inner));
+        return childs;
+    }
+
+    @Override
+    public boolean isLeaf() {
+        return false;
+    }
+
+}


### PR DESCRIPTION
When traversing a java.util.Optional, the application crashes. 
Add a new OptionalNode class that correctly displays the optional object.

This is the error that the application throws when trying to inspect an Optional type.
`Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException: Cannot invoke "java.util.List.size()" because the return value of "introspector.model.AbstractNode.getChildren()" is null
        at introspector.model.AbstractNode.getChildrenCount(AbstractNode.java:104)
        at introspector.model.IntrospectorModel.getChildCount(IntrospectorModel.java:6`

This patch fixes the issue.

## Example
When present:
![28-02-2025_12-46-37](https://github.com/user-attachments/assets/c9046d31-c3a3-4a3e-8c0f-1114f967fd09)

When empty:
![28-02-2025_12-47-07](https://github.com/user-attachments/assets/34b38929-6d89-4a95-b7b0-839b7343e018)
